### PR TITLE
feat: allow using compatible drivers

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "kysely-tables",
   "description": "Use the same Kysely types for your SQL table schema, migrations and queries.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/package/package.json
+++ b/package/package.json
@@ -50,9 +50,6 @@
     "prettier": "^3.5.3",
     "tsx": "^4.19.4"
   },
-  "exports": {
-    "./*": "./dist/*"
-  },
   "typesVersions": {
     "*": {
       "*": [


### PR DESCRIPTION
The instanceof check in `getPostgratorClient` limits the driver selection to `pg` and `better-sqlite3`. This change permits any compatible driver, though not in the most elegant way, as it adds an option. I'm open to other ideas.

I also removed a duplicate "exports" field from package.json.

This is published as `@gekorm/kysely-tables` if you wish to try it.

_____

I would also like to use this as an opportunity to thank you for writing this package. I evaluated kysely-ctl, prisma and drizzle and agonized for months over the migrations workflow as none quite hit the spot. This is a really promising project!